### PR TITLE
fix: Resolve dataChannel scoping issue for voice calls

### DIFF
--- a/templates/chat.html
+++ b/templates/chat.html
@@ -33,6 +33,38 @@
         </div>
     </div>
 
+    <hr>
+
+    <div id="voice-call-controls" style="margin-top: 15px; padding: 10px; border: 1px solid #ddd;">
+        <h3>Voice Call</h3>
+        <div>
+            <button id="call-button">Call Peer</button>
+            <button id="hangup-button" style="display:none;">Hang Up</button>
+            <button id="accept-call-button" style="display:none;">Accept Call</button>
+            <button id="reject-call-button" style="display:none;">Reject Call</button>
+        </div>
+        <div style="margin-top: 10px;">
+            Call Status: <span id="call-status">Idle</span>
+        </div>
+        <div style="margin-top: 10px;">
+            <label for="audio-input-select">Audio Input:</label>
+            <select id="audio-input-select">
+                <option value="">Default</option>
+            </select>
+        </div>
+        <div style="margin-top: 5px;">
+            <label for="audio-output-select">Audio Output:</label>
+            <select id="audio-output-select">
+                <option value="">Default</option>
+            </select>
+        </div>
+        <div style="margin-top: 5px;">
+            <label for="output-volume-slider">Output Volume:</label>
+            <input type="range" id="output-volume-slider" min="0" max="1" step="0.01" value="1">
+        </div>
+        <!-- The <audio id="remote-audio"> element will be created and managed by main.js -->
+    </div>
+
     <script>
         const USERNAME = "{{ username }}";
         const ROOM_NAME = "{{ room_name }}";


### PR DESCRIPTION
Corrects a `ReferenceError: dataChannel is not defined` that occurred within the `sendDataChannelMessage` function when initiating voice calls.

The root cause was that `sendDataChannelMessage` was defined in the global scope, while the `dataChannel` variable it relied upon was scoped within the `DOMContentLoaded` event listener.

Changes:
- Moved the `sendDataChannelMessage` function definition into the `DOMContentLoaded` scope, allowing it to correctly access the `dataChannel` variable.
- Added a defensive check at the beginning of `sendDataChannelMessage` to log a critical error if `dataChannel` is ever undefined in its scope, aiding in diagnosing any future regressions.
- Reviewed and confirmed that the existing guard clause in the call button's click handler (checking if `dataChannel` is defined and open) remains relevant and effective.

This ensures that voice call signaling messages can be reliably sent over the WebRTC data channel.